### PR TITLE
allow setting of TDS_Version in the DSN

### DIFF
--- a/src/SqlServerConnector.php
+++ b/src/SqlServerConnector.php
@@ -59,6 +59,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
         "ServerSPN",
         "StatsLog_On",
         "StatsLogFile",
+        "TDS_Version",
         "Trusted_Connection",
         "TrustServerCertificate",
 //        "UID",


### PR DESCRIPTION
Although not documented, TDS_Version is a valid option in the DSN. In my setup it is required to connect to a recent MSSQL server version